### PR TITLE
Simplify citsigol map for iteration

### DIFF
--- a/src/citsigol/demo.py
+++ b/src/citsigol/demo.py
@@ -13,8 +13,8 @@ def main() -> None:
     """Demo script for citsigol."""
     print("Welcome to citsigol!")
 
-    r_resolution = 24001
-    n_steps = 4000
+    r_resolution = 2001
+    n_steps = 1000
     n_skip = 400
     r_limits = (2, 4)
     # plot the classic bifurcation diagram of the logistic map
@@ -49,26 +49,22 @@ def main() -> None:
 
     # plot the citsigol map with a few different r and target values
     print("Plotting the citsigol map with a few different r and target values...")
-    n_iterations = 50
+    n_iterations = 10
     r_values = [0.5, 1.5, 2.5, math.pi, 3.5, 3.8]
-    target_values = [0.25, 0.6, 1 / math.pi]
-    exes = []
-    for target in target_values:
-        plt.figure(figsize=(21, 11))
-        plt.title("Citsigol Map with Compass")
-        plt.xlabel("n")
-        plt.ylabel("x_n")
-        for r in r_values:
-            print(f"r={r:.5f}, target={target:.5f}")
-            compass = citsigol.Seeker(target)
-            steps = list(range(n_iterations + 1))
-            exes = citsigol.Citsigol(r).sequence(max(0.1, r / 5), n_iterations, compass)
-            plt.plot(steps[: len(exes)], exes, label=f"r={r}")
-        plt.legend()
-        plt.title("Citsigol Map with Compass")
-        plt.plot([0, len(exes)], [target, target], "k--", label="target")
-        plt.xlabel("n")
-        plt.ylabel("x_n")
+    plt.figure(figsize=(21, 11))
+    plt.title("Citsigol Map with Compass")
+    plt.xlabel("n")
+    plt.ylabel("x_n")
+    for r in r_values:
+        print(f"r={r:.5f}")
+        exes = citsigol.Citsigol(r).sequence(max(0.1, r / 5), n_iterations)
+        steps = [step for i, x in enumerate(exes) for step in len(x) * [i]]
+        plot_exes = [x for xs in exes for x in xs]
+        plt.plot(steps, plot_exes, ".", label=f"r={r}")
+    plt.legend()
+    plt.title("Citsigol Map with Compass")
+    plt.xlabel("n")
+    plt.ylabel("x_n")
     plt.show()
 
 

--- a/tests/test_citsigol.py
+++ b/tests/test_citsigol.py
@@ -1,21 +1,39 @@
-#!/usr/bin/env python
-
 """Tests for `citsigol` package."""
 
 import pytest
 
-
-@pytest.fixture
-def response():
-    """Sample pytest fixture.
-
-    See more at: http://doc.pytest.org/en/latest/fixture.html
-    """
-    # import requests
-    # return requests.get('https://github.com/audreyr/cookiecutter-pypackage')
+import citsigol
 
 
-def test_content(response):
-    """Sample pytest test function with the pytest fixture as an argument."""
-    # from bs4 import BeautifulSoup
-    # assert 'GitHub' in BeautifulSoup(response.content).title.string
+def test_citsigol_map():
+    """Test the citsigol function call."""
+    citsigol_map = citsigol.Citsigol(1.0)
+    assert citsigol_map(0.125) == pytest.approx(
+        [
+            0.5 * (1 - (1 - 0.125 * 4.0 / 1) ** 0.5),
+            0.5 * (1 + (1 - 0.125 * 4.0 / 1) ** 0.5),
+        ]
+    )
+    assert citsigol_map(0.125, branch=1) == pytest.approx(
+        [0.5 * (1 + (1 - 0.125 * 4.0 / 1) ** 0.5)]
+    )
+    assert citsigol_map(0.125, branch=-1) == pytest.approx(
+        [0.5 * (1 - (1 - 0.125 * 4.0 / 1) ** 0.5)]
+    )
+    assert citsigol_map([0.125, 0.25]) == pytest.approx(
+        [
+            0.5 * (1 - (1 - 0.125 * 4.0 / 1) ** 0.5),
+            0.5 * (1 + (1 - 0.125 * 4.0 / 1) ** 0.5),
+            0.5 * (1 - (1 - 0.25 * 4.0 / 1) ** 0.5),
+            0.5 * (1 + (1 - 0.25 * 4.0 / 1) ** 0.5),
+        ]
+    )
+    assert not citsigol_map(0.5)  # empty list since this is out of bounds
+
+
+def test_citsigol_sequence():
+    """Test the citsigol sequence function."""
+    citsigol_map = citsigol.Citsigol(1.0)
+    assert citsigol_map.sequence(0.125, 2)[-1] == citsigol_map(
+        citsigol_map.sequence(0.125, 1)[-1]
+    )


### PR DESCRIPTION
Making the citsigol map a bit more straightforward for now. Will add the smarts on top later.

The basic idea here:

Given an x and a branch choice in [-1, 0, 1], the citsigol map will return:

the lower branch, if branch = -1
the upper branch, if branch = 1
both branches, if branch = 0

Since x can be a list of values, it will potentially grow (up to double the length) each time it is called with branch = 0. This can cause problems with memory when using Citsigol.sequence, so that will have to be handled in a later update.